### PR TITLE
Add responsive design, fix validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ To install pelican-youtube, simply install it from PyPI:
 
     $ pip install pelican-youtube
 
-Then enabled it in your pelicanconf.py
+Then enable it in your pelicanconf.py
 
 .. code-block:: python
 
@@ -27,7 +27,7 @@ Then enabled it in your pelicanconf.py
 Usage
 =====
 
-In your article or page, you simply need to add a line to embed you video.
+In your article or page, you simply need to add a line to embed your video.
 
 .. code-block:: rst
 
@@ -37,29 +37,87 @@ Which will result in:
 
 .. code-block:: html
 
-    <div class="youtube" align="left">
-    <iframe width="420" height="315" src="https://www.youtube.com/embed/VIDEO_ID" frameborder="0"></iframe>
+    <div class="youtube youtube-16x9">
+    <iframe src="https://www.youtube.com/embed/VIDEO_ID" allowfullscreen seamless frameBorder="0"></iframe>
     </div>
+
+.. note::
+
+    This code will render you a fully responsive YouTube video, spanning the
+    whole available container width.  Note that you will need to integrate the
+    code from `youtube.css`_ in your project or template style sheet.
+    Alternatively, you can specify `width` and `height` as detailed below.
+
+
+.. _youtube.css: https://github.com/kura/pelican_youtube/blob/master/youtube.css
 
 Additional arguments
 --------------------
 
-You can also specify a `width`, `height` and `alignment`
+====================== ================= ======================================
+Attribute              default
+====================== ================= ======================================
+`allowfullscreen`      ``yes``           allow video to be displayed full-screen
+`seamless`             ``yes``           no borders around iframe
+`class`                ``youtube-16x9``, additional CSS classes, usually for responsive behavior
+                       empty°            (° when `width` or `height` are specified)
+`width`, `height`      empty             video dimensions when responsive design is not desired
+====================== ================= ======================================
+
+Example 1: (responsive design)
 
 .. code-block:: rst
 
-	.. youtube:: 37818131
-        :width: 800
-        :height: 500
-        :align: center
+    .. youtube:: 4_X6EyqXa2s
+        :class: youtube-4x3
+        :allowfullscreen: no
+        :seamless: no
 
-Which will result in:
+Will result in:
 
 .. code-block:: html
 
-    <div class="youtube" align="center">
-    <iframe width="800" height="500" src="https://www.youtube.com/embed/37818131" frameborder="0"></iframe>
+    <div class="youtube youtube-4x3">
+    <iframe src="https://www.youtube.com/embed/4_X6EyqXa2s"></iframe>
     </div>
+
+Example 2: (non-responsive design)
+
+.. code-block:: rst
+
+    .. youtube:: 4_X6EyqXa2s
+        :width: 800
+        :height: 500
+        :allowfullscreen: no
+
+Will result in:
+
+.. code-block:: html
+
+    <div class="youtube">
+    <iframe width="800" height="500" src="https://www.youtube.com/embed/4_X6EyqXa2s" seamless frameBorder="0"></iframe>
+    </div>
+
+More Control of YouTube Video Player
+------------------------------------
+
+YouTube offers more control via player parameters, which you simply attach to the VIDEO_ID
+as query parameters.  See `YouTube documentation`_ for a list of possible parameters.
+
+Example: (start video at time 00:20, start playing automatically, don't show related content at end of video)
+
+.. code-block:: rst
+
+    .. youtube:: 4_X6EyqXa2s?start=20&amp;autoplay=1&amp;rel=0
+
+
+.. _YouTube documentation: https://developers.google.com/youtube/player_parameters#Parameters
+
+Known Issues
+------------
+
+The presence of the ``frameBorder`` attribute causes an HTML5 validation error.  Unfortunately,
+this attribute is still necessary for supporting older versions of Internet Explorer.
 
 License
 =======

--- a/pelican_youtube/__init__.py
+++ b/pelican_youtube/__init__.py
@@ -19,9 +19,9 @@
 
 # -*- coding: utf-8 -*-
 __title__ = 'pelican-youtube'
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 __author__ = 'Kura'
-__credits__ = ["Kura", ]
+__credits__ = ["Kura", "Peter Bittner"]
 __maintainer__ = "Kura"
 __email__ = "kura@kura.io"
 __status__ = "Stable"

--- a/youtube.css
+++ b/youtube.css
@@ -1,0 +1,37 @@
+/*
+ * Responsive design style sheet for pelican YouTube integration.
+ * Makes the video as wide as possible, keeping a specified aspect ratio
+ * of the video (e.g. 4:3, 16:9, etc. for width vs height).  The video
+ * will resize and shrink as you resize the browser window.  Enjoy!
+ *
+ * Integrate these definitions into your project style sheet, and use as
+ *
+ * <div class="youtube youtube-16x9">
+ *     <iframe src="https://www.youtube.com/embed/VIDEO_ID" allowfullscreen seamless frameborder="0"></iframe>
+ * </div>
+ *
+ * (c) 2015 Peter Bittner <django@bittner.it>, license: MIT
+ */
+
+.youtube-4x3 {
+	padding-bottom: 75%;  /* inverse of 4:3 aspect ratio */
+}
+.youtube-16x9 {
+	padding-bottom: 56.25%;  /* inverse of 16:9 aspect ratio */
+}
+.youtube-4x3,
+.youtube-16x9 {
+	position: relative;
+	height: 0;
+	overflow: hidden;
+}
+.youtube-4x3 iframe,
+.youtube-16x9 iframe {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	border: 0;
+}


### PR DESCRIPTION
This PR fixes validation errors and adds the, now mandatory, `allowfullscreen` attribute for `iframe`. In addition, it makes responsive design the norm for pelican generated YouTube embeds. The old, non-responsive behavior is still supported (simply explicitly specify width and height).

- Make embedded YouTube videos ready for responsive design
- Make generated code HTML5 valid (except for IE `frameBorder`)
- Add missing `allowfullscreen` attribute, add `seamless` attribute
- Update README with new instructions
- Add CSS sample file for including in own template or project
* Bump version number: 0.1.0 --> 0.2.0

## Backward compatibility

The changes break backward-compatibility (`align` attribute in reST directive is now gone).  It's difficult to include a sensible upgrade path with deprecations. I think it should be fine to break things, and provide version **0.1.0** with the old behavior, and a new version **0.2.0** with the new features and API. After all, also browsers and YouTube broke things in the meantime.

The troublesome `frameborder` iframe attribute has been changed to `frameBorder`, this way [even IE 7 is covered](http://stackoverflow.com/questions/65034/remove-border-from-iframe).