### PR TITLE
Add an option to disable YouTube tracking cookies

### DIFF
--- a/pelican_youtube/youtube.py
+++ b/pelican_youtube/youtube.py
@@ -43,13 +43,14 @@ class YouTube(Directive):
         return value in ('yes', 'True')
 
     required_arguments = 1
-    optional_arguments = 5
+    optional_arguments = 6
     option_spec = {
         'class': directives.unchanged,
         'width': directives.positive_int,
         'height': directives.positive_int,
         'allowfullscreen': boolean,
         'seamless': boolean,
+        'nocookie': boolean,
     }
 
     final_argument_whitespace = False
@@ -57,7 +58,11 @@ class YouTube(Directive):
 
     def run(self):
         videoID = self.arguments[0].strip()
-        url = 'https://www.youtube.com/embed/{}'.format(videoID)
+        # Choose whether to use the YouTube nocookie domain for reduced tracking.
+        nocookie = self.options['nocookie'] \
+            if 'nocookie' in self.options else False
+        youtube_domain = 'youtube-nocookie' if nocookie else 'youtube'
+        url = 'https://www.{}.com/embed/{}'.format(youtube_domain, videoID)
 
         width = self.options['width'] if 'width' in self.options else None
         height = self.options['height'] if 'height' in self.options else None


### PR DESCRIPTION
Came across [How to remove YouTube tracking](https://dri.es/how-to-remove-youtube-tracking) and was curious if I could do this with pelican_youtube...doesn't look easy out of the box, but was able to add a quick option for it.

This domain seems to be pretty widely mentioned (e.g. a [StackOverflow](https://stackoverflow.com/questions/42555450/how-to-embed-youtube-videos-without-cookies)), but I haven't been able to find docs on it.