### PR TITLE
Fix link to CSS style sheet (README)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Which will result in:
     Alternatively, you can specify `width` and `height` as detailed below.
 
 
-.. _youtube.css: https://github.com/kura/pelican_youtube/blob/master/youtube.css
+.. _youtube.css: https://github.com/kura/pelican_youtube/blob/main/pelican/plugins/youtube/youtube.css
 
 Additional arguments
 --------------------


### PR DESCRIPTION
Updates the setup instructions link that points to the CSS file.

This is a follow-up on #17.