### PR TITLE
Use pdm as build-backend (instead of setuptools)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-exclude Makefile
-include README.rst LICENSE pelican/plugins/youtube/youtube.css

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ pypi: build
 	uv publish
 
 clean: uv
-	uvx pyclean . --debris
+	uvx pyclean . --debris --erase .pdm-build/**/* .pdm-build/.gitignore .pdm-build --yes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [build-system]
-build-backend = "setuptools.build_meta"
-requires = ["setuptools>=64"]
+build-backend = "pdm.backend"
+requires = ["pdm-backend"]
 
 [project]
 name = "pelican-youtube"
 version = "0.3.0"
 description = "Easily embed YouTube videos in your posts"
 readme = "README.rst"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "Kura", email = "kura@kura.gg"},
     {name = "Peter Bittner", email = "django@gittner.it"},
@@ -18,7 +19,6 @@ maintainers = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
@@ -41,5 +41,11 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/kura/pelican_youtube"
 
-[tool.setuptools]
-packages = ["pelican.plugins.youtube"]
+[tool.pdm.build]
+includes = [
+    "pelican/",
+]
+excludes = [
+    "Makefile",
+    "**/.DS_Store",
+]


### PR DESCRIPTION
Setuptools doesn't support the new `license` and `license-files` fields yet.

The [Pelican Search plugin](https://github.com/pelican-plugins/search) uses PDM as build backend, hence we'll try that as well.

Follow-up on #17.

## References

- [Declaring a build backend in `pyproject.toml`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#declaring-the-build-backend) (Python Packaging User Guide)
- [Choosing a build backend](https://packaging.python.org/en/latest/tutorials/packaging-projects/#choosing-a-build-backend) (Python Packaging User Guide)